### PR TITLE
Remove tour counter functionality

### DIFF
--- a/include/ligneBus.h
+++ b/include/ligneBus.h
@@ -36,6 +36,5 @@ void ajouterStationsEtTroncons(TlisteStation *newLigne, TlisteStation ligne);
 TlisteStation jonctionLigneDeBus(TlisteStation ligne1, TlisteStation ligne2);
 void supprimerStation(TlisteStation *ligne, int idStation);
 void circulaire(TlisteStation *ligne);
-void compteurTours(int *tourCount, Tbus bus);
 
 #endif // LIGNEBUS_H_INCLUDED

--- a/include/ligneBus.h
+++ b/include/ligneBus.h
@@ -36,5 +36,6 @@ void ajouterStationsEtTroncons(TlisteStation *newLigne, TlisteStation ligne);
 TlisteStation jonctionLigneDeBus(TlisteStation ligne1, TlisteStation ligne2);
 void supprimerStation(TlisteStation *ligne, int idStation);
 void circulaire(TlisteStation *ligne);
+void compteurTours(int *tourCount, Tbus bus);
 
 #endif // LIGNEBUS_H_INCLUDED

--- a/src/main.c
+++ b/src/main.c
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
                         SDL_Delay(1); // valeur du delai modifiable en fonction de votre CPU
                         ++frame;
 
-                        // Compteur de tours
+                        compteurTours(&tourCount, bus1);
                 }
                 // fin boucle du jeu
         }

--- a/src/main.c
+++ b/src/main.c
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
                 // SUPRESSION D'UNE STATION DE BUS POUR TEST (NE PAS EFFACER)
 
                 // TEST DE LA FONCTION CIRCULAIRE (NE PAS EFFACER)
-                //circulaire(&lignesBus[0]);
+                circulaire(&lignesBus[0]);
                 // TEST DE LA FONCTION CIRCULAIRE (NE PAS EFFACER)
 
                 int tourCount = -1;

--- a/src/main.c
+++ b/src/main.c
@@ -202,7 +202,6 @@ int main(int argc, char *argv[])
                         SDL_Delay(1); // valeur du delai modifiable en fonction de votre CPU
                         ++frame;
 
-                        compteurTours(&tourCount, bus1);
                 }
                 // fin boucle du jeu
         }


### PR DESCRIPTION
Eliminate the tour counter from the circular function, streamlining the code for better performance.